### PR TITLE
Bring inline with Perl 1.0.4 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: ruby
+rvm:
+  - jruby-head
+  - 2.2.2
+  - 2.1.6
+  - 2.0.0
+  - rbx-2
+  - ruby-head
+jdk:
+  - openjdk7
+  - oraclejdk7
+
+sudo: false
+cache: bundler
+
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      jdk: openjdk7
+    - rvm: 2.0.0
+      jdk: oraclejdk7
+    - rvm: 2.1.6
+      jdk: openjdk7
+    - rvm: 2.1.6
+      jdk: oraclejdk7
+    - rvm: 2.2.2
+      jdk: openjdk7
+    - rvm: 2.2.2
+      jdk: oraclejdk7
+    - rvm: ruby-head
+      jdk: openjdk7
+    - rvm: ruby-head
+      jdk: oraclejdk7
+    - rvm: rbx-2
+      jdk: openjdk7
+    - rvm: rbx-2
+      jdk: oraclejdk7
+
+env:
+  - RAKE_TASK="test"
+
+script: "bundle exec rake $RAKE_TASK"


### PR DESCRIPTION
hello,

This is a pretty significant rewrite, which brings it inline with the perl version.  The main behavior changes are:
* all perl tests pass
* the `: informal` flag is removed (we can put it back in)

besides having a passing perl test suite, @schwern rewrote everything to use regexp.  In our informal testing, this improved processing speed by 13x as it wasn't recompiling the regexs every time.

If this is too large a merge, and I understand if it is, please let me know what you would like to see be changed.  And we are also able and willing to take over this project and move it forward if you would like.

cheers,
Adam