### PR TITLE
Handle streets where the name overlaps the street-type map

### DIFF
--- a/lib/street_address.rb
+++ b/lib/street_address.rb
@@ -581,6 +581,14 @@ module StreetAddress
     # note that expressions like [^,]+ may scan more than you expect
     self.street_regexp = /
       (?:
+        # special case for addresses like 14168 W River Rd and 3301 N Park
+        # Blvd, where the street name matches one of the street types
+        (?:
+           (?<prefix> #{direct_regexp})\W+
+           (?<street> [^\d]+)\W+
+           (?<street_type> #{street_type_regexp})\b
+        )
+        |
         # special case for addresses like 100 South Street
         (?:(?<street> #{direct_regexp})\W+
            (?<street_type> #{street_type_regexp})\b

--- a/test/street_address_test.rb
+++ b/test/street_address_test.rb
@@ -259,6 +259,36 @@ class StreetAddressUsTest < MiniTest::Test
       :street_type => 'Rd',
       :state => 'CO'
     },
+    "14168 W RIVER RD   \nCOLUMBIA STATION, OH 44028-9430" => {  # overlapping street type and road name
+      :city => 'Columbia Station',
+      :postal_code => '44028',
+      :postal_code_ext => '9430',
+      :number => '14168',
+      :street => 'River',
+      :street_type => 'Rd',
+      :state => 'OH',
+      :prefix => 'W'
+    },
+    "555 E LAKE AVE    \nBELLEFONTAINE, OH 43311-2509" => {
+      :city => 'Bellefontaine',
+      :postal_code => '43311',
+      :postal_code_ext => '2509',
+      :number => '555',
+      :street => 'Lake',
+      :street_type => 'Ave',
+      :state => 'OH',
+      :prefix => 'E'
+    },
+    "19600 N PARK BLVD    \nSHAKER HEIGHTS, OH 44122-1825" => {
+      :city => 'Shaker Heights',
+      :postal_code => '44122',
+      :postal_code_ext => '1825',
+      :number => '19600',
+      :street => 'Park',
+      :street_type => 'Blvd',
+      :state => 'OH',
+      :prefix => 'N'
+    },
     "1234 COUNTY HWY 60E, Town, CO 12345" => {
       :city => 'Town',
       :postal_code => '12345',


### PR DESCRIPTION
Some addresses like

```
14168 W RIVER RD
COLUMBIA STATION, OH 44028-9430
```

are interpreted with the street being "W", the street type as "River"
(which abbreviates to "riv"), and the city as "RD   \nCOLUMBIA STATION".
The example addresses are all in Ohio because that's my current data set,
but it's not an Ohio-specific phenomenon: for example, in Illinois,
there's a River Road that follows the Des Plaines River.

The erroneous parse appears to be from the "100 South Street"
special case in the street regexp.  This commit adds a second special
case with higher precedence, matching [prefix, non-numeric street,
street type] sequences.  The street match excludes numerics to preserve
the existing parse behavior for the "6641 N 2200 W Apt D304 Park City,
UT 84098" case.